### PR TITLE
feat: improve mod9710 function

### DIFF
--- a/ascii/ascii.go
+++ b/ascii/ascii.go
@@ -1,9 +1,5 @@
 package ascii
 
-func IsLowerCase(r rune) bool {
-	return 'a' <= r && r <= 'z'
-}
-
 func IsUpperCaseLetter(r rune) bool {
 	return 'A' <= r && r <= 'Z'
 }
@@ -13,7 +9,7 @@ func IsDigit(r rune) bool {
 }
 
 func IsAlphaNumeric(r rune) bool {
-	return IsDigit(r) || IsLowerCase(r) || IsUpperCaseLetter(r)
+	return IsDigit(r) || IsUpperCaseLetter(r)
 }
 
 func IsUpperAlphaNumeric(r rune) bool {

--- a/iban/checksum_test.go
+++ b/iban/checksum_test.go
@@ -10,20 +10,20 @@ import (
 	"time"
 )
 
-func BenchmarkCompute(b *testing.B) {
-	b.ReportAllocs()
-
-	for i := 0; i < b.N; i++ {
-		v := mod9710Chunked("105000997603123456789123")
-		_ = v
-	}
-}
-
 func BenchmarkBigIntMod9710(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
 		v := bigIntMod9710("105000997603123456789123")
+		_ = v
+	}
+}
+
+func BenchmarkMod9710(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		v := mod9710("105000997603123456789123")
 		_ = v
 	}
 }
@@ -59,7 +59,7 @@ func TestModuloFunctions(t *testing.T) {
 		},
 	}
 
-	if err := quick.CheckEqual(bigIntMod9710, mod9710Chunked, cfg); err != nil {
+	if err := quick.CheckEqual(bigIntMod9710, mod9710, cfg); err != nil {
 		t.Errorf("test failed %v", err)
 	}
 }


### PR DESCRIPTION
improve mod9710 function

before:
```
BenchmarkCompute-12    	53518566	        22.28 ns/op	       0 B/op	       0 allocs/op
```

after
```
BenchmarkMod9710-12    	209476284	         5.728 ns/op	       0 B/op	       0 allocs/op
```