### PR TITLE
fix: correct account number lengths for Montenegro and Sweden BBANs

### DIFF
--- a/docs/registry.yml
+++ b/docs/registry.yml
@@ -464,7 +464,7 @@ countries:
     BBAN: 3!n13!n2!n
     bank_code: 0:3
     national_checksum: 16:18
-    account_number: 3:18
+    account_number: 3:16
     sepa: false
 
   - code: MK
@@ -647,7 +647,7 @@ countries:
     BBAN: 3!n16!n1!n
     bank_code: 0:3
     national_checksum: 19:20
-    account_number: 3:20
+    account_number: 3:19
     sepa: true
 
   - code: SI

--- a/iban/bban_test.go
+++ b/iban/bban_test.go
@@ -490,7 +490,7 @@ func TestBBAN(t *testing.T) {
 				BankCode:         "505",
 				BranchCode:       "",
 				NationalChecksum: "51",
-				AccountNumber:    "000012345678951"},
+				AccountNumber:    "0000123456789"},
 		},
 		{
 			iban:    "NL91ABNA0417164300",
@@ -660,7 +660,7 @@ func TestBBAN(t *testing.T) {
 				BankCode:         "500",
 				BranchCode:       "",
 				NationalChecksum: "6",
-				AccountNumber:    "00000058398257466"},
+				AccountNumber:    "0000005839825746"},
 		},
 		{
 			iban:    "CH9300762011623852957",

--- a/iban/country_montenegro.go
+++ b/iban/country_montenegro.go
@@ -51,6 +51,6 @@ func getMontenegroBBAN(iban string) (BBAN, error) {
 		BankCode:         iban[4:7],
 		BranchCode:       "",
 		NationalChecksum: iban[20:22],
-		AccountNumber:    iban[7:22],
+		AccountNumber:    iban[7:20],
 	}, nil
 }

--- a/iban/country_sweden.go
+++ b/iban/country_sweden.go
@@ -51,6 +51,6 @@ func getSwedenBBAN(iban string) (BBAN, error) {
 		BankCode:         iban[4:7],
 		BranchCode:       "",
 		NationalChecksum: iban[23:24],
-		AccountNumber:    iban[7:24],
+		AccountNumber:    iban[7:23],
 	}, nil
 }


### PR DESCRIPTION
- Updated the account number lengths in the registry for Montenegro and Sweden.
- Adjusted test cases to reflect these changes.