### PR TITLE
refactor(iban)!: replace validation error types

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ true
 
 ### Validation Errors
 
-Validation returns structured errors that work with `errors.As`.
+Validation returns structured errors that work with `errors.Is` and `errors.As`.
 
 ```go
 package main
@@ -96,28 +96,34 @@ import (
 func main() {
 	err := iban.Validate("GB99INVALID")
 
-	var lengthErr *iban.ErrValidationLength
-	if errors.As(err, &lengthErr) {
-		fmt.Printf("invalid length: expected %d, got %d\n", lengthErr.Expected, lengthErr.Actual)
+	if errors.Is(err, iban.ErrInvalidIBAN) {
+		fmt.Println("invalid IBAN")
 	}
 
-	fmt.Println(iban.IsValidationError(err))
+	var validationErr *iban.ValidationError
+	if errors.As(err, &validationErr) && validationErr.Reason == iban.ReasonInvalidLength {
+		fmt.Printf("invalid length: expected %d, got %d\n",
+			validationErr.ExpectedLength,
+			validationErr.ActualLength)
+	}
 }
 ```
 
 Output:
 
 ```text
+invalid IBAN
 invalid length: expected 22, got 11
-true
 ```
 
-Other validation error types:
+Validation reasons:
 
-- `*iban.ErrValidationChecksum`
-- `*iban.ErrValidationRange`
-- `*iban.ErrValidationStaticValue`
-- `*iban.ErrUnsupportedCountry`
+- `iban.ReasonInvalidLength`
+- `iban.ReasonInvalidChecksum`
+- `iban.ReasonInvalidCharacters`
+- `iban.ReasonUnsupportedCountry`
+
+Country-code APIs such as `Generate` and `IsSEPACountryCode` return `*iban.CountryCodeError`.
 
 ## BIC
 

--- a/cmd/wasmiban/main.go
+++ b/cmd/wasmiban/main.go
@@ -31,47 +31,47 @@ func humanizeError(err error) string {
 		return ""
 	}
 
-	var lengthErr *iban.ErrValidationLength
-	if errors.As(err, &lengthErr) {
-		return fmt.Sprintf("Invalid length (expected %d characters)", lengthErr.Expected)
-	}
+	var validationErr *iban.ValidationError
+	if errors.As(err, &validationErr) {
+		switch validationErr.Reason {
+		case iban.ReasonInvalidLength:
+			return fmt.Sprintf("Invalid length (expected %d characters)", validationErr.ExpectedLength)
+		case iban.ReasonInvalidChecksum:
+			return "Invalid checksum"
+		case iban.ReasonInvalidCharacters:
+			if validationErr.ExpectedValue != "" {
+				if validationErr.Position == 0 {
+					return fmt.Sprintf("Invalid country code (expected %s)", validationErr.ExpectedValue)
+				}
+				return "Invalid format - expected specific value"
+			}
+			endPos := validationErr.Position + validationErr.Length - 1
 
-	var checksumErr *iban.ErrValidationChecksum
-	if errors.As(err, &checksumErr) {
-		return "Invalid checksum"
-	}
+			var typeDesc string
+			switch validationErr.Expected {
+			case iban.CharClassDigit:
+				typeDesc = "only digits"
+			case iban.CharClassUpperAlpha:
+				typeDesc = "only letters"
+			case iban.CharClassUpperAlphaNumeric:
+				typeDesc = "letters and digits"
+			default:
+				typeDesc = validationErr.Expected.String()
+			}
 
-	var rangeErr *iban.ErrValidationRange
-	if errors.As(err, &rangeErr) {
-		endPos := rangeErr.Position + rangeErr.Length - 1
-
-		var typeDesc string
-		switch rangeErr.Expected {
-		case iban.CharacterTypeDigit:
-			typeDesc = "only digits"
-		case iban.CharacterTypeUpperCase:
-			typeDesc = "only letters"
-		case iban.CharacterTypeAlphaNumeric:
-			typeDesc = "letters and digits"
-		default:
-			typeDesc = rangeErr.Expected.String()
+			return fmt.Sprintf("Invalid characters between position %d and %d - %s allowed",
+				validationErr.Position, endPos, typeDesc)
+		case iban.ReasonUnsupportedCountry:
+			return fmt.Sprintf("Country code '%s' is not supported", validationErr.Actual)
 		}
-
-		return fmt.Sprintf("Invalid characters between position %d and %d - %s allowed",
-			rangeErr.Position, endPos, typeDesc)
 	}
 
-	var staticErr *iban.ErrValidationStaticValue
-	if errors.As(err, &staticErr) {
-		if staticErr.Position == 0 {
-			return fmt.Sprintf("Invalid country code (expected %s)", staticErr.Expected)
+	var countryCodeErr *iban.CountryCodeError
+	if errors.As(err, &countryCodeErr) {
+		if errors.Is(err, iban.ErrUnsupportedCountry) {
+			return fmt.Sprintf("Country code '%s' is not supported", countryCodeErr.CountryCode)
 		}
-		return "Invalid format - expected specific value"
-	}
-
-	var unsupportedErr *iban.ErrUnsupportedCountry
-	if errors.As(err, &unsupportedErr) {
-		return fmt.Sprintf("Country code '%s' is not supported", unsupportedErr.CountryCode)
+		return fmt.Sprintf("Country code '%s' is invalid", countryCodeErr.CountryCode)
 	}
 
 	return err.Error()
@@ -111,8 +111,8 @@ func validateIBAN(this js.Value, args []js.Value) any {
 	if err != nil {
 		data.FormattedIBAN = iban.PaperFormat(ibanStr)
 
-		var checksumErr *iban.ErrValidationChecksum
-		if errors.As(err, &checksumErr) {
+		var validationErr *iban.ValidationError
+		if errors.As(err, &validationErr) && validationErr.Reason == iban.ReasonInvalidChecksum {
 			if corrected, corrErr := iban.ReplaceChecksum(ibanStr); corrErr == nil {
 				data.CorrectedIBAN = iban.PaperFormat(corrected)
 			}

--- a/iban/bban_test.go
+++ b/iban/bban_test.go
@@ -841,22 +841,41 @@ func TestGetBBANRejectsInvalidIBAN(t *testing.T) {
 	tests := []struct {
 		name string
 		iban string
-		want any
+		want iban.ValidationError
 	}{
 		{
 			name: "invalid checksum",
 			iban: "GB00NWBK60161331926819",
-			want: (*iban.ErrValidationChecksum)(nil),
+			want: iban.ValidationError{
+				Reason:        iban.ReasonInvalidChecksum,
+				Position:      2,
+				Length:        2,
+				Expected:      iban.CharClassDigit,
+				Actual:        "00",
+				ExpectedValue: "29",
+			},
 		},
 		{
 			name: "invalid range",
 			iban: "GB29NWBK6016133192681X",
-			want: (*iban.ErrValidationRange)(nil),
+			want: iban.ValidationError{
+				Reason:   iban.ReasonInvalidCharacters,
+				Position: 8,
+				Length:   14,
+				Expected: iban.CharClassDigit,
+				Actual:   "6016133192681X",
+			},
 		},
 		{
 			name: "unsupported country",
 			iban: "ZZ29NWBK60161331926819",
-			want: (*iban.ErrUnsupportedCountry)(nil),
+			want: iban.ValidationError{
+				Reason:   iban.ReasonUnsupportedCountry,
+				Position: 0,
+				Length:   2,
+				Expected: iban.CharClassUpperAlpha,
+				Actual:   "ZZ",
+			},
 		},
 	}
 
@@ -866,23 +885,31 @@ func TestGetBBANRejectsInvalidIBAN(t *testing.T) {
 			if err == nil {
 				t.Fatalf("GetBBAN() error = nil, got BBAN %+v", got)
 			}
-			switch tt.want.(type) {
-			case *iban.ErrValidationChecksum:
-				var target *iban.ErrValidationChecksum
-				if !errors.As(err, &target) {
-					t.Fatalf("GetBBAN() error = %T, want ErrValidationChecksum", err)
-				}
-			case *iban.ErrValidationRange:
-				var target *iban.ErrValidationRange
-				if !errors.As(err, &target) {
-					t.Fatalf("GetBBAN() error = %T, want ErrValidationRange", err)
-				}
-			case *iban.ErrUnsupportedCountry:
-				var target *iban.ErrUnsupportedCountry
-				if !errors.As(err, &target) {
-					t.Fatalf("GetBBAN() error = %T, want ErrUnsupportedCountry", err)
-				}
-			}
+			assertValidationError(t, err, tt.want)
 		})
+	}
+}
+
+func assertValidationError(t *testing.T, err error, want iban.ValidationError) {
+	t.Helper()
+
+	if !errors.Is(err, iban.ErrInvalidIBAN) {
+		t.Fatalf("errors.Is(err, ErrInvalidIBAN) = false, want true")
+	}
+
+	var got *iban.ValidationError
+	if !errors.As(err, &got) {
+		t.Fatalf("errors.As(err, *ValidationError) = false, want true")
+	}
+
+	if got.Reason != want.Reason ||
+		got.Position != want.Position ||
+		got.Length != want.Length ||
+		got.Expected != want.Expected ||
+		got.Actual != want.Actual ||
+		got.ExpectedValue != want.ExpectedValue ||
+		got.ExpectedLength != want.ExpectedLength ||
+		got.ActualLength != want.ActualLength {
+		t.Fatalf("ValidationError = %+v, want %+v", got, want)
 	}
 }

--- a/iban/checksum.go
+++ b/iban/checksum.go
@@ -5,7 +5,7 @@ const decimalDigits = "0123456789"
 // ReplaceChecksum returns the IBAN with corrected check digits.
 func ReplaceChecksum(iban string) (string, error) {
 	if len(iban) < 4 {
-		return "", &ErrValidationLength{Expected: 4, Actual: len(iban)}
+		return "", invalidIBANLength(4, len(iban))
 	}
 	if err := validateIBANStructure(iban); err != nil {
 		return "", err
@@ -24,7 +24,7 @@ func validateChecksum(iban string) error {
 	if expected[0] == iban[2] && expected[1] == iban[3] {
 		return nil
 	}
-	return &ErrValidationChecksum{Expected: string(expected[:]), Actual: iban[2:4]}
+	return invalidIBANChecksum(string(expected[:]), iban[2:4])
 }
 
 // calculateCheckDigits calculates IBAN check digits and writes them to checkBuf.

--- a/iban/checksum_test.go
+++ b/iban/checksum_test.go
@@ -107,27 +107,50 @@ func TestReplaceChecksumRejectsInvalidStructure(t *testing.T) {
 	tests := []struct {
 		name string
 		iban string
-		want any
+		want ValidationError
 	}{
 		{
 			name: "too short",
 			iban: "GB1",
-			want: (*ErrValidationLength)(nil),
+			want: ValidationError{
+				Reason:         ReasonInvalidLength,
+				Length:         4,
+				ExpectedLength: 4,
+				ActualLength:   3,
+			},
 		},
 		{
 			name: "non-digit check digits",
 			iban: "GBXXNWBK60161331926819",
-			want: (*ErrValidationRange)(nil),
+			want: ValidationError{
+				Reason:   ReasonInvalidCharacters,
+				Position: 2,
+				Length:   2,
+				Expected: CharClassDigit,
+				Actual:   "XX",
+			},
 		},
 		{
 			name: "invalid BBAN character",
 			iban: "GB29NWBK6016133192681X",
-			want: (*ErrValidationRange)(nil),
+			want: ValidationError{
+				Reason:   ReasonInvalidCharacters,
+				Position: 8,
+				Length:   14,
+				Expected: CharClassDigit,
+				Actual:   "6016133192681X",
+			},
 		},
 		{
 			name: "unsupported country",
 			iban: "ZZ29NWBK60161331926819",
-			want: (*ErrUnsupportedCountry)(nil),
+			want: ValidationError{
+				Reason:   ReasonUnsupportedCountry,
+				Position: 0,
+				Length:   2,
+				Expected: CharClassUpperAlpha,
+				Actual:   "ZZ",
+			},
 		},
 	}
 
@@ -136,25 +159,33 @@ func TestReplaceChecksumRejectsInvalidStructure(t *testing.T) {
 			if got, err := ReplaceChecksum(tt.iban); err == nil {
 				t.Fatalf("ReplaceChecksum() error = nil, got %q", got)
 			} else {
-				switch tt.want.(type) {
-				case *ErrValidationLength:
-					var target *ErrValidationLength
-					if !errors.As(err, &target) {
-						t.Fatalf("ReplaceChecksum() error = %T, want ErrValidationLength", err)
-					}
-				case *ErrValidationRange:
-					var target *ErrValidationRange
-					if !errors.As(err, &target) {
-						t.Fatalf("ReplaceChecksum() error = %T, want ErrValidationRange", err)
-					}
-				case *ErrUnsupportedCountry:
-					var target *ErrUnsupportedCountry
-					if !errors.As(err, &target) {
-						t.Fatalf("ReplaceChecksum() error = %T, want ErrUnsupportedCountry", err)
-					}
-				}
+				assertValidationError(t, err, tt.want)
 			}
 		})
+	}
+}
+
+func assertValidationError(t *testing.T, err error, want ValidationError) {
+	t.Helper()
+
+	if !errors.Is(err, ErrInvalidIBAN) {
+		t.Fatalf("errors.Is(err, ErrInvalidIBAN) = false, want true")
+	}
+
+	var got *ValidationError
+	if !errors.As(err, &got) {
+		t.Fatalf("errors.As(err, *ValidationError) = false, want true")
+	}
+
+	if got.Reason != want.Reason ||
+		got.Position != want.Position ||
+		got.Length != want.Length ||
+		got.Expected != want.Expected ||
+		got.Actual != want.Actual ||
+		got.ExpectedValue != want.ExpectedValue ||
+		got.ExpectedLength != want.ExpectedLength ||
+		got.ActualLength != want.ActualLength {
+		t.Fatalf("ValidationError = %+v, want %+v", got, want)
 	}
 }
 

--- a/iban/error.go
+++ b/iban/error.go
@@ -5,98 +5,202 @@ import (
 	"fmt"
 )
 
-// CharacterType represents the expected character type in IBAN range validation
-type CharacterType int
+var (
+	// ErrInvalidIBAN reports an invalid IBAN.
+	ErrInvalidIBAN = errors.New("invalid IBAN")
 
-const (
-	CharacterTypeDigit CharacterType = iota
-	CharacterTypeUpperCase
-	CharacterTypeAlphaNumeric
+	// ErrInvalidCountryCode reports an invalid ISO 3166-1 alpha-2 country code.
+	ErrInvalidCountryCode = errors.New("invalid country code")
+
+	// ErrUnsupportedCountry reports a syntactically valid country code that this
+	// registry does not support.
+	ErrUnsupportedCountry = errors.New("unsupported country")
 )
 
-// String returns the string representation of CharacterType
-func (ct CharacterType) String() string {
-	switch ct {
-	case CharacterTypeDigit:
-		return "Digit"
-	case CharacterTypeUpperCase:
-		return "UpperCase"
-	case CharacterTypeAlphaNumeric:
-		return "AlphaNumeric"
+// ValidationReason identifies why IBAN validation failed.
+type ValidationReason uint8
+
+const (
+	ReasonInvalidLength ValidationReason = iota + 1
+	ReasonInvalidChecksum
+	ReasonInvalidCharacters
+	ReasonUnsupportedCountry
+)
+
+func (r ValidationReason) String() string {
+	switch r {
+	case ReasonInvalidLength:
+		return "invalid length"
+	case ReasonInvalidChecksum:
+		return "invalid checksum"
+	case ReasonInvalidCharacters:
+		return "invalid characters"
+	case ReasonUnsupportedCountry:
+		return "unsupported country"
 	default:
-		return "Unknown"
+		return "unknown"
 	}
 }
 
-// ErrValidationLength represents an IBAN length validation error
-type ErrValidationLength struct {
-	Expected int
-	Actual   int
+// CharClass identifies the expected character class for an IBAN span.
+type CharClass uint8
+
+const (
+	CharClassDigit CharClass = iota + 1
+	CharClassUpperAlpha
+	CharClassUpperAlphaNumeric
+)
+
+func (c CharClass) String() string {
+	switch c {
+	case CharClassDigit:
+		return "digit"
+	case CharClassUpperAlpha:
+		return "uppercase letter"
+	case CharClassUpperAlphaNumeric:
+		return "uppercase letter or digit"
+	default:
+		return "unknown"
+	}
 }
 
-func (e *ErrValidationLength) Error() string {
-	return fmt.Sprintf("unexpected length, want: %d, got: %d", e.Expected, e.Actual)
-}
+// ValidationError contains machine-readable IBAN validation diagnostics.
+type ValidationError struct {
+	Reason ValidationReason
 
-// ErrValidationChecksum represents an IBAN checksum validation error
-type ErrValidationChecksum struct {
-	Expected string
-	Actual   string
-}
-
-func (e *ErrValidationChecksum) Error() string {
-	return fmt.Sprintf("incorrect checksum, expected: %s, got: %s", e.Expected, e.Actual)
-}
-
-// ErrValidationRange represents an IBAN range validation error
-type ErrValidationRange struct {
+	// Position and Length identify the invalid IBAN span when applicable.
 	Position int
 	Length   int
-	Expected CharacterType
+
+	// Expected identifies the required character class for ReasonInvalidCharacters.
+	Expected CharClass
 	Actual   string
+
+	// ExpectedValue is set when a precise expected value exists, such as
+	// checksum digits or registry static values.
+	ExpectedValue string
+
+	// ExpectedLength and ActualLength are set for ReasonInvalidLength.
+	ExpectedLength int
+	ActualLength   int
 }
 
-func (e *ErrValidationRange) Error() string {
-	return fmt.Sprintf("range rule, start pos: %d, length: %d, expected type: %s, found: %s",
-		e.Position, e.Length, e.Expected.String(), e.Actual)
+func (e *ValidationError) Error() string {
+	if e == nil {
+		return ErrInvalidIBAN.Error()
+	}
+	switch e.Reason {
+	case ReasonInvalidLength:
+		return fmt.Sprintf("invalid IBAN length: want %d, got %d", e.ExpectedLength, e.ActualLength)
+	case ReasonInvalidChecksum:
+		return fmt.Sprintf("invalid IBAN checksum: want %s, got %s", e.ExpectedValue, e.Actual)
+	case ReasonInvalidCharacters:
+		if e.ExpectedValue != "" {
+			return fmt.Sprintf("invalid IBAN value at position %d: want %s, got %s", e.Position, e.ExpectedValue, e.Actual)
+		}
+		return fmt.Sprintf("invalid IBAN characters at position %d: want %s, got %s", e.Position, e.Expected, e.Actual)
+	case ReasonUnsupportedCountry:
+		return fmt.Sprintf("unsupported IBAN country %s", e.Actual)
+	default:
+		return ErrInvalidIBAN.Error()
+	}
 }
 
-// ErrValidationStaticValue represents an IBAN static value validation error
-type ErrValidationStaticValue struct {
-	Position int
-	Expected string
-	Actual   string
-}
-
-func (e *ErrValidationStaticValue) Error() string {
-	return fmt.Sprintf("static value rule, pos: %d, expected value: %s, found: %s",
-		e.Position, e.Expected, e.Actual)
-}
-
-// ErrUnsupportedCountry represents an error for unsupported country codes
-type ErrUnsupportedCountry struct {
-	CountryCode string
-}
-
-func (e *ErrUnsupportedCountry) Error() string {
-	return fmt.Sprintf("country code %s is not supported", e.CountryCode)
-}
-
-// IsValidationError reports whether err is any validation error from this library
-func IsValidationError(err error) bool {
-	if err == nil {
+func (e *ValidationError) Is(target error) bool {
+	if e == nil {
 		return false
 	}
+	return target == ErrInvalidIBAN ||
+		target == ErrUnsupportedCountry && e.Reason == ReasonUnsupportedCountry
+}
 
-	var lengthErr *ErrValidationLength
-	var checksumErr *ErrValidationChecksum
-	var rangeErr *ErrValidationRange
-	var staticErr *ErrValidationStaticValue
-	var unsupportedErr *ErrUnsupportedCountry
+// CountryCodeError contains machine-readable country-code diagnostics.
+type CountryCodeError struct {
+	CountryCode string
+	Err         error
+}
 
-	return errors.As(err, &lengthErr) ||
-		errors.As(err, &checksumErr) ||
-		errors.As(err, &rangeErr) ||
-		errors.As(err, &staticErr) ||
-		errors.As(err, &unsupportedErr)
+func (e *CountryCodeError) Error() string {
+	if e == nil || e.Err == nil {
+		return ErrInvalidCountryCode.Error()
+	}
+	switch {
+	case errors.Is(e.Err, ErrUnsupportedCountry):
+		return fmt.Sprintf("unsupported country code %s", e.CountryCode)
+	case errors.Is(e.Err, ErrInvalidCountryCode):
+		return fmt.Sprintf("invalid country code %s", e.CountryCode)
+	default:
+		return e.Err.Error()
+	}
+}
+
+func (e *CountryCodeError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func invalidIBANLength(expected, actual int) error {
+	return &ValidationError{
+		Reason:         ReasonInvalidLength,
+		Length:         expected,
+		ExpectedLength: expected,
+		ActualLength:   actual,
+	}
+}
+
+func invalidIBANChecksum(expected, actual string) error {
+	return &ValidationError{
+		Reason:        ReasonInvalidChecksum,
+		Position:      2,
+		Length:        2,
+		Expected:      CharClassDigit,
+		Actual:        actual,
+		ExpectedValue: expected,
+	}
+}
+
+func invalidIBANCharacters(position, length int, expected CharClass, actual string) error {
+	return &ValidationError{
+		Reason:   ReasonInvalidCharacters,
+		Position: position,
+		Length:   length,
+		Expected: expected,
+		Actual:   actual,
+	}
+}
+
+func invalidIBANValue(position int, expected, actual string) error {
+	return &ValidationError{
+		Reason:        ReasonInvalidCharacters,
+		Position:      position,
+		Length:        len(expected),
+		Actual:        actual,
+		ExpectedValue: expected,
+	}
+}
+
+func unsupportedIBANCountry(countryCode string) error {
+	return &ValidationError{
+		Reason:   ReasonUnsupportedCountry,
+		Position: 0,
+		Length:   len(countryCode),
+		Expected: CharClassUpperAlpha,
+		Actual:   countryCode,
+	}
+}
+
+func invalidCountryCode(countryCode string) error {
+	return &CountryCodeError{
+		CountryCode: countryCode,
+		Err:         ErrInvalidCountryCode,
+	}
+}
+
+func unsupportedCountry(countryCode string) error {
+	return &CountryCodeError{
+		CountryCode: countryCode,
+		Err:         ErrUnsupportedCountry,
+	}
 }

--- a/iban/error_test.go
+++ b/iban/error_test.go
@@ -8,65 +8,107 @@ import (
 	"github.com/jacoelho/banking/iban"
 )
 
-func TestIsValidationError(t *testing.T) {
+func TestValidationErrorMatchesInvalidIBAN(t *testing.T) {
+	err := &iban.ValidationError{
+		Reason:   iban.ReasonInvalidCharacters,
+		Position: 4,
+		Length:   3,
+		Expected: iban.CharClassUpperAlpha,
+		Actual:   "123",
+	}
+
+	if !errors.Is(err, iban.ErrInvalidIBAN) {
+		t.Fatalf("errors.Is(err, ErrInvalidIBAN) = false, want true")
+	}
+	if errors.Is(err, iban.ErrUnsupportedCountry) {
+		t.Fatalf("errors.Is(err, ErrUnsupportedCountry) = true, want false")
+	}
+
+	wrapped := fmt.Errorf("wrapped: %w", err)
+	var got *iban.ValidationError
+	if !errors.As(wrapped, &got) {
+		t.Fatalf("errors.As(wrapped, *ValidationError) = false, want true")
+	}
+	if got.Reason != iban.ReasonInvalidCharacters ||
+		got.Position != 4 ||
+		got.Length != 3 ||
+		got.Expected != iban.CharClassUpperAlpha ||
+		got.Actual != "123" {
+		t.Fatalf("ValidationError = %+v", got)
+	}
+}
+
+func TestValidationErrorMatchesUnsupportedCountry(t *testing.T) {
+	err := &iban.ValidationError{
+		Reason:   iban.ReasonUnsupportedCountry,
+		Position: 0,
+		Length:   2,
+		Expected: iban.CharClassUpperAlpha,
+		Actual:   "ZZ",
+	}
+
+	if !errors.Is(err, iban.ErrInvalidIBAN) {
+		t.Fatalf("errors.Is(err, ErrInvalidIBAN) = false, want true")
+	}
+	if !errors.Is(err, iban.ErrUnsupportedCountry) {
+		t.Fatalf("errors.Is(err, ErrUnsupportedCountry) = false, want true")
+	}
+}
+
+func TestCountryCodeErrorMatching(t *testing.T) {
 	tests := []struct {
 		name string
 		err  error
-		want bool
+		want error
 	}{
 		{
-			name: "nil error",
-			err:  nil,
-			want: false,
+			name: "invalid country code",
+			err: &iban.CountryCodeError{
+				CountryCode: "G",
+				Err:         iban.ErrInvalidCountryCode,
+			},
+			want: iban.ErrInvalidCountryCode,
 		},
 		{
-			name: "non-validation error",
-			err:  fmt.Errorf("some other error"),
-			want: false,
-		},
-		{
-			name: "ErrValidationLength",
-			err:  &iban.ErrValidationLength{Expected: 22, Actual: 20},
-			want: true,
-		},
-		{
-			name: "ErrValidationChecksum",
-			err:  &iban.ErrValidationChecksum{Expected: "97", Actual: "00"},
-			want: true,
-		},
-		{
-			name: "ErrValidationRange",
-			err:  &iban.ErrValidationRange{Position: 4, Length: 8, Expected: iban.CharacterTypeDigit, Actual: "ABC12345"},
-			want: true,
-		},
-		{
-			name: "ErrValidationStaticValue",
-			err:  &iban.ErrValidationStaticValue{Position: 0, Expected: "GB", Actual: "XX"},
-			want: true,
-		},
-		{
-			name: "ErrUnsupportedCountry",
-			err:  &iban.ErrUnsupportedCountry{CountryCode: "XX"},
-			want: true,
-		},
-		{
-			name: "wrapped validation error",
-			err:  fmt.Errorf("wrapper: %w", &iban.ErrValidationLength{Expected: 22, Actual: 20}),
-			want: true,
-		},
-		{
-			name: "wrapped non-validation error",
-			err:  fmt.Errorf("wrapper: %w", errors.New("not validation")),
-			want: false,
+			name: "unsupported country",
+			err: &iban.CountryCodeError{
+				CountryCode: "ZZ",
+				Err:         iban.ErrUnsupportedCountry,
+			},
+			want: iban.ErrUnsupportedCountry,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := iban.IsValidationError(tt.err)
-			if got != tt.want {
-				t.Errorf("IsValidationError() = %v, want %v", got, tt.want)
+			wrapped := fmt.Errorf("wrapped: %w", tt.err)
+			if !errors.Is(wrapped, tt.want) {
+				t.Fatalf("errors.Is(wrapped, %v) = false, want true", tt.want)
+			}
+
+			var got *iban.CountryCodeError
+			if !errors.As(wrapped, &got) {
+				t.Fatalf("errors.As(wrapped, *CountryCodeError) = false, want true")
 			}
 		})
+	}
+}
+
+func TestValidateReturnsStructuredCharacterError(t *testing.T) {
+	err := iban.Validate("GB29NWBK6016133192681X")
+	if err == nil {
+		t.Fatalf("Validate() error = nil, want error")
+	}
+
+	var got *iban.ValidationError
+	if !errors.As(err, &got) {
+		t.Fatalf("errors.As(err, *ValidationError) = false, want true")
+	}
+	if got.Reason != iban.ReasonInvalidCharacters ||
+		got.Position != 8 ||
+		got.Length != 14 ||
+		got.Expected != iban.CharClassDigit ||
+		got.Actual != "6016133192681X" {
+		t.Fatalf("ValidationError = %+v", got)
 	}
 }

--- a/iban/generate.go
+++ b/iban/generate.go
@@ -2,12 +2,12 @@ package iban
 
 // Generate generates an IBAN based on ISO 3166-1 country code.
 func Generate(countryCode string) (string, error) {
-	if len(countryCode) != 2 {
-		return "", &ErrValidationLength{Expected: 2, Actual: len(countryCode)}
+	if !validCountryCode(countryCode) {
+		return "", invalidCountryCode(countryCode)
 	}
 	country, ok := lookupCountry(countryCode)
 	if !ok {
-		return "", &ErrUnsupportedCountry{CountryCode: countryCode}
+		return "", unsupportedCountry(countryCode)
 	}
 	return country.generate(), nil
 }

--- a/iban/generate_test.go
+++ b/iban/generate_test.go
@@ -1,6 +1,9 @@
 package iban
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestGenerate(t *testing.T) {
 	t.Parallel()
@@ -18,5 +21,55 @@ func TestGenerate(t *testing.T) {
 				t.Fatal(err)
 			}
 		})
+	}
+}
+
+func TestGenerateRejectsInvalidCountryCode(t *testing.T) {
+	tests := []struct {
+		name        string
+		countryCode string
+		want        error
+	}{
+		{
+			name:        "too short",
+			countryCode: "G",
+			want:        ErrInvalidCountryCode,
+		},
+		{
+			name:        "lowercase",
+			countryCode: "gb",
+			want:        ErrInvalidCountryCode,
+		},
+		{
+			name:        "unsupported",
+			countryCode: "ZZ",
+			want:        ErrUnsupportedCountry,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Generate(tt.countryCode)
+			if err == nil {
+				t.Fatalf("Generate() error = nil, got %q", got)
+			}
+			assertCountryCodeError(t, err, tt.countryCode, tt.want)
+		})
+	}
+}
+
+func assertCountryCodeError(t *testing.T, err error, countryCode string, want error) {
+	t.Helper()
+
+	if !errors.Is(err, want) {
+		t.Fatalf("errors.Is(err, %v) = false, want true", want)
+	}
+
+	var got *CountryCodeError
+	if !errors.As(err, &got) {
+		t.Fatalf("errors.As(err, *CountryCodeError) = false, want true")
+	}
+	if got.CountryCode != countryCode {
+		t.Fatalf("CountryCodeError.CountryCode = %q, want %q", got.CountryCode, countryCode)
 	}
 }

--- a/iban/registry.go
+++ b/iban/registry.go
@@ -54,6 +54,14 @@ func lookupCountry(code string) (*countrySpec, bool) {
 	return &countrySpecs[int(index)-1], true
 }
 
+func validCountryCode(code string) bool {
+	if len(code) != 2 {
+		return false
+	}
+	_, ok := countryIndexSlot(code)
+	return ok
+}
+
 // countryIndexSlot requires a two-byte country code. Public callers validate
 // length before slicing or calling lookupCountry.
 func countryIndexSlot(code string) (int, bool) {
@@ -65,7 +73,7 @@ func countryIndexSlot(code string) (int, bool) {
 
 func (c *countrySpec) validate(iban string) error {
 	if len(iban) != c.length {
-		return &ErrValidationLength{Expected: c.length, Actual: len(iban)}
+		return invalidIBANLength(c.length, len(iban))
 	}
 	for _, rule := range c.rules {
 		start := int(rule.start)
@@ -75,32 +83,27 @@ func (c *countrySpec) validate(iban string) error {
 		switch rule.kind {
 		case ibanRuleStatic:
 			if subject != rule.value {
-				return &ErrValidationStaticValue{Position: start, Expected: rule.value, Actual: subject}
+				return invalidIBANValue(start, rule.value, subject)
 			}
 		case ibanRuleDigit:
 			if !ascii.IsDigit(subject) {
-				return validationRangeError(rule, subject, CharacterTypeDigit)
+				return validationCharacterError(rule, subject, CharClassDigit)
 			}
 		case ibanRuleUpperCase:
 			if !ascii.IsUpperCase(subject) {
-				return validationRangeError(rule, subject, CharacterTypeUpperCase)
+				return validationCharacterError(rule, subject, CharClassUpperAlpha)
 			}
 		case ibanRuleAlphaNumeric:
 			if !ascii.IsAlphaNumeric(subject) {
-				return validationRangeError(rule, subject, CharacterTypeAlphaNumeric)
+				return validationCharacterError(rule, subject, CharClassUpperAlphaNumeric)
 			}
 		}
 	}
 	return nil
 }
 
-func validationRangeError(rule ibanRule, actual string, expected CharacterType) error {
-	return &ErrValidationRange{
-		Position: int(rule.start),
-		Length:   int(rule.length),
-		Expected: expected,
-		Actual:   actual,
-	}
+func validationCharacterError(rule ibanRule, actual string, expected CharClass) error {
+	return invalidIBANCharacters(int(rule.start), int(rule.length), expected, actual)
 }
 
 func (c *countrySpec) generate() string {

--- a/iban/sepa.go
+++ b/iban/sepa.go
@@ -2,16 +2,13 @@ package iban
 
 // IsSEPACountryCode reports whether a country code is a SEPA member.
 func IsSEPACountryCode(countryCode string) (bool, error) {
-	if len(countryCode) != 2 {
-		return false, &ErrValidationLength{Expected: 2, Actual: len(countryCode)}
+	if !validCountryCode(countryCode) {
+		return false, invalidCountryCode(countryCode)
 	}
-	slot, ok := countryIndexSlot(countryCode)
-	if !ok {
-		return false, &ErrUnsupportedCountry{CountryCode: countryCode}
-	}
+	slot, _ := countryIndexSlot(countryCode)
 	entry := countryCodeIndex[slot]
 	if entry&countryIndexMask == 0 {
-		return false, &ErrUnsupportedCountry{CountryCode: countryCode}
+		return false, unsupportedCountry(countryCode)
 	}
 	return entry&countrySEPAFlag != 0, nil
 }

--- a/iban/sepa_test.go
+++ b/iban/sepa_test.go
@@ -313,3 +313,40 @@ func TestIsSEPAValidatesIBAN(t *testing.T) {
 		t.Fatalf("IsSEPA() = false, want true")
 	}
 }
+
+func TestIsSEPACountryCodeRejectsInvalidCountryCode(t *testing.T) {
+	tests := []struct {
+		name        string
+		countryCode string
+		want        error
+	}{
+		{
+			name:        "too short",
+			countryCode: "G",
+			want:        ErrInvalidCountryCode,
+		},
+		{
+			name:        "lowercase",
+			countryCode: "gb",
+			want:        ErrInvalidCountryCode,
+		},
+		{
+			name:        "unsupported",
+			countryCode: "ZZ",
+			want:        ErrUnsupportedCountry,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := IsSEPACountryCode(tt.countryCode)
+			if err == nil {
+				t.Fatalf("IsSEPACountryCode() error = nil, got %v", got)
+			}
+			if got {
+				t.Fatalf("IsSEPACountryCode() = true, want false")
+			}
+			assertCountryCodeError(t, err, tt.countryCode, tt.want)
+		})
+	}
+}

--- a/iban/validate.go
+++ b/iban/validate.go
@@ -3,12 +3,15 @@ package iban
 // validateIBANStructure validates an IBAN without comparing checksum.
 func validateIBANStructure(iban string) error {
 	if len(iban) < 2 {
-		return &ErrValidationLength{Expected: 2, Actual: len(iban)}
+		return invalidIBANLength(2, len(iban))
 	}
 	code := iban[0:2]
+	if !validCountryCode(code) {
+		return invalidIBANCharacters(0, 2, CharClassUpperAlpha, code)
+	}
 	country, ok := lookupCountry(code)
 	if !ok {
-		return &ErrUnsupportedCountry{CountryCode: code}
+		return unsupportedIBANCountry(code)
 	}
 	return country.validate(iban)
 }


### PR DESCRIPTION
Replaces the exported ErrValidation* structs with sentinel errors, a structured ValidationError, and CountryCodeError. Callers now use errors.Is for categories and errors.As for diagnostics such as reason, span, character class, and actual value.

BREAKING CHANGE: 

ErrValidationLength, ErrValidationChecksum, ErrValidationRange, ErrValidationStaticValue, CharacterType, and IsValidationError were removed. 

Use ErrInvalidIBAN, ErrInvalidCountryCode, ErrUnsupportedCountry, ValidationError, CountryCodeError, ValidationReason, and CharClass instead.